### PR TITLE
fix: Nextcloud redirect, validations, port 53 blocking

### DIFF
--- a/plugin/validate.go
+++ b/plugin/validate.go
@@ -15,16 +15,18 @@ type validatorFunc func(v config.Value, tree config.TreeReader) ([]config.Valida
 // validators maps config paths to their validation functions.
 // Only paths that need validation are listed -- unlisted paths are always valid.
 var validators = map[string]validatorFunc{
-	"core/domain":                validateRequired,
-	"core/data-root":             validateAbsolutePath,
-	"pihole/dns-port":            validatePiholeDNSPort,
-	"pihole/admin-password":      validateRequired,
-	"plex/media-movies":          validateOptionalAbsPath,
-	"plex/media-tv":              validateOptionalAbsPath,
-	"plex/media-music":           validateOptionalAbsPath,
-	"nextcloud/admin-password":   validateRequired,
-	"mariadb/root-password":      validateRequired,
-	"mariadb/nextcloud-password": validateRequired,
+	"core/domain":                    validateRequired,
+	"core/data-root":                 validateAbsolutePath,
+	"pihole/dns-port":                validatePiholeDNSPort,
+	"pihole/admin-password":          validateRequired,
+	"plex/media-movies":              validateOptionalAbsPath,
+	"plex/media-tv":                  validateOptionalAbsPath,
+	"plex/media-music":               validateOptionalAbsPath,
+	"plex/claim-token":               validatePlexClaimToken,
+	"nextcloud/admin-password":       validateRequired,
+	"nextcloud/trusted-domains":      validateTrustedDomains,
+	"mariadb/root-password":          validateRequired,
+	"mariadb/nextcloud-password":     validateRequired,
 }
 
 func validateRequired(v config.Value, _ config.TreeReader) ([]config.ValidationResult, error) {
@@ -60,6 +62,30 @@ func validateOptionalAbsPath(v config.Value, _ config.TreeReader) ([]config.Vali
 	return nil, nil
 }
 
+func validatePlexClaimToken(v config.Value, _ config.TreeReader) ([]config.ValidationResult, error) {
+	s, _ := v.Val.(string)
+	if s == "" {
+		return []config.ValidationResult{{
+			Message:  "Plex claim token is empty. Your server will start unclaimed and won't be accessible remotely. Get a token from https://plex.tv/claim (valid 4 minutes).",
+			Severity: config.Warning,
+		}}, nil
+	}
+	return nil, nil
+}
+
+func validateTrustedDomains(v config.Value, tree config.TreeReader) ([]config.ValidationResult, error) {
+	s, _ := v.Val.(string)
+	domain, _ := tree.Get("core/domain")
+	domainStr, _ := domain.Val.(string)
+	if domainStr != "" && s == "localhost" {
+		return []config.ValidationResult{{
+			Message:  fmt.Sprintf("Trusted domains is still 'localhost' but core/domain is set to '%s'. Add your domain to trusted domains to avoid access errors.", domainStr),
+			Severity: config.Warning,
+		}}, nil
+	}
+	return nil, nil
+}
+
 func validatePiholeDNSPort(v config.Value, _ config.TreeReader) ([]config.ValidationResult, error) {
 	s := fmt.Sprintf("%v", v.Val)
 	port, err := strconv.ParseFloat(s, 64)
@@ -71,8 +97,8 @@ func validatePiholeDNSPort(v config.Value, _ config.TreeReader) ([]config.Valida
 	}
 	if port == 53 {
 		return []config.ValidationResult{{
-			Message:  "Port 53 may conflict with systemd-resolved. Run: sudo sed -i 's/#DNSStubListener=yes/DNSStubListener=no/' /etc/systemd/resolved.conf && sudo systemctl restart systemd-resolved",
-			Severity: config.Warning,
+			Message:  "Port 53 may conflict with systemd-resolved. Run: sudo mkdir -p /etc/systemd/resolved.conf.d && echo -e '[Resolve]\\nDNSStubListener=no' | sudo tee /etc/systemd/resolved.conf.d/no-stub.conf && sudo systemctl restart systemd-resolved",
+			Severity: config.Blocking,
 		}}, nil
 	}
 	return nil, nil

--- a/plugin/validate_test.go
+++ b/plugin/validate_test.go
@@ -86,7 +86,7 @@ func TestValidatePiholeDNSPort(t *testing.T) {
 		severity config.Severity
 		hasResult bool
 	}{
-		{"port 53 warns", 53, config.Warning, true},
+		{"port 53 blocks", 53, config.Blocking, true},
 		{"port 5353 passes", 5353, 0, false},
 		{"non-number blocks", "abc", config.Blocking, true},
 		{"float port passes", 8053.0, 0, false},

--- a/workspace/templates/apply.sh.tmpl
+++ b/workspace/templates/apply.sh.tmpl
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_PROJECT="{{ .Get "core/compose-project-name" | default "home-server" }}"
+DOMAIN="{{ .Get "core/domain" }}"
+NC_PORT="{{ .Get "nextcloud/web-port" | default "8080" }}"
+
+echo "==> Starting home-server stack..."
+docker compose -p "$COMPOSE_PROJECT" up -d --wait
+
+{{- if .ComponentEnabled "nextcloud" }}
+
+echo "==> Configuring Nextcloud overwrite settings..."
+# Wait for Nextcloud to be ready (first install can take a while)
+for i in $(seq 1 60); do
+  if docker exec nextcloud php occ status --output=json 2>/dev/null | grep -q '"installed":true'; then
+    break
+  fi
+  echo "    Waiting for Nextcloud to finish installation... ($i/60)"
+  sleep 5
+done
+
+docker exec -u www-data nextcloud php occ config:system:set trusted_domains 0 --value="$DOMAIN"
+docker exec -u www-data nextcloud php occ config:system:set trusted_domains 1 --value="localhost"
+{{- if ne $NC_PORT "80" }}
+docker exec -u www-data nextcloud php occ config:system:set overwritehost --value="$DOMAIN:$NC_PORT"
+docker exec -u www-data nextcloud php occ config:system:set overwrite.cli.url --value="http://$DOMAIN:$NC_PORT"
+{{- else }}
+docker exec -u www-data nextcloud php occ config:system:set overwritehost --value="$DOMAIN"
+docker exec -u www-data nextcloud php occ config:system:set overwrite.cli.url --value="http://$DOMAIN"
+{{- end }}
+echo "    Nextcloud configured for $DOMAIN"
+{{- end }}
+
+echo "==> Done! Services:"
+docker compose -p "$COMPOSE_PROJECT" ps --format "table {{`{{.Name}}`}}\t{{`{{.Status}}`}}\t{{`{{.Ports}}`}}"

--- a/workspace/zhi.yaml
+++ b/workspace/zhi.yaml
@@ -49,15 +49,16 @@ export:
     - name: docker-compose
       template: ./templates/docker-compose.yml.tmpl
       output: ./docker-compose.yml
+    - name: apply-script
+      template: ./templates/apply.sh.tmpl
+      output: ./apply.sh
 
 apply:
   targets:
     default:
-      command: "docker compose up -d --remove-orphans --force-recreate --wait"
+      command: "bash ./apply.sh"
       workdir: "."
       pre-export: true
-      env:
-        COMPOSE_PROJECT_NAME: "home-server"
       timeout: 300
     stop:
       command: "docker compose down"


### PR DESCRIPTION
Combined fix for multiple issues:

**Nextcloud redirect (#3):** Adds `apply.sh` template that configures `overwritehost` and `overwrite.cli.url` post-installation, fixing the port-stripping redirect issue.

**Trusted domains (#3):** Adds validation warning when `core/domain` is set but `nextcloud/trusted-domains` is still `localhost`.

**Plex claim token (#5):** Adds validation warning when claim token is empty.

**Port 53 (#8):** Makes port 53 conflict a blocking validation (was warning) and fixes the remediation command to work on Fedora/Arch (uses drop-in config instead of editing `resolved.conf` directly).

Closes #3, closes #5, closes #8