### PR TITLE
feat: healthchecks, Redis 8, MariaDB binlog opt-in

### DIFF
--- a/plugin/values.go
+++ b/plugin/values.go
@@ -235,6 +235,12 @@ var valueDefs = []ValueDef{
 		Type:        "string", Password: true, Required: true,
 	},
 	{
+		Path: "mariadb/enable-binlog", Default: false,
+		Section: "Replication", DisplayName: "Enable Binary Logging",
+		Description: "Enable binary logging for replication. Disabled by default to save disk space on home servers.",
+		Type:        "bool",
+	},
+	{
 		Path: "mariadb/innodb-buffer-pool-size", Default: "256M",
 		Section: "Tuning", DisplayName: "InnoDB Buffer Pool Size",
 		Description: "InnoDB buffer pool size (e.g., 256M, 1G)",
@@ -243,7 +249,7 @@ var valueDefs = []ValueDef{
 
 	// ── redis ─────────────────────────────────────────────────────────────
 	{
-		Path: "redis/image-tag", Default: "7-alpine",
+		Path: "redis/image-tag", Default: "8-alpine",
 		Section: "Image", DisplayName: "Redis Image Tag",
 		Description: "Docker image tag for redis",
 		Type:        "string",

--- a/workspace/templates/docker-compose.yml.tmpl
+++ b/workspace/templates/docker-compose.yml.tmpl
@@ -38,6 +38,12 @@ services:
       - pihole-dnsmasq:/etc/dnsmasq.d
     networks:
       - frontend
+    healthcheck:
+      test: ["CMD", "dig", "+norecurse", "+retry=0", "@127.0.0.1", "pi.hole"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 {{- end }}
 
 {{- if .ComponentEnabled "plex" }}
@@ -78,8 +84,10 @@ services:
     command: >-
       --innodb-buffer-pool-size={{ .Get "mariadb/innodb-buffer-pool-size" | default "256M" }}
       --transaction-isolation=READ-COMMITTED
+{{- if eq (.Get "mariadb/enable-binlog" | default "false") "true" }}
       --log-bin=binlog
       --binlog-format=ROW
+{{- end }}
     networks:
       - backend
     healthcheck:
@@ -91,7 +99,7 @@ services:
 
 {{- if .ComponentEnabled "redis" }}
   redis:
-    image: redis:{{ .Get "redis/image-tag" | default "7-alpine" }}
+    image: redis:{{ .Get "redis/image-tag" | default "8-alpine" }}
     container_name: redis
     restart: unless-stopped
     command: >-
@@ -148,6 +156,12 @@ services:
     networks:
       - frontend
       - backend
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/status.php"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
 {{- end }}
 
 {{- if .ComponentEnabled "nginx-proxy-manager" }}


### PR DESCRIPTION
Template improvements:

- **Healthchecks:** Added for Nextcloud (`curl /status.php`) and PiHole (`dig pi.hole`). MariaDB and Redis already had them.
- **Redis:** Updated default image tag from `7-alpine` to `8-alpine`.
- **MariaDB:** Binary logging is now opt-in via `mariadb/enable-binlog` (default: false). Saves disk on home servers that don't need replication.

Closes #4